### PR TITLE
Quick quote pop closing issue fix 

### DIFF
--- a/FormControls/MyDateField/index.js
+++ b/FormControls/MyDateField/index.js
@@ -4,7 +4,6 @@ import { Button, DatePicker } from "antd";
 import "antd/dist/antd.css"; // or 'antd/dist/antd.less'
 import { useField } from "formik";
 import moment from "moment";
-import { Box } from "@mui/material";
 import quickQuoteStyles from "../../styles/QuickQuote.module.css";
 
 const MyDateField = ({...props }) => {

--- a/FormControls/MyDateField/index.js
+++ b/FormControls/MyDateField/index.js
@@ -12,19 +12,32 @@ const MyDateField = ({...props }) => {
   const { touched, error } = meta;
   const { setValue } = helpers;
 
+  const datePickerRef = React.useRef(null);
+
+  React.useEffect(() => {
+    document.addEventListener("click", handleDocumentClick);
+
+    return () => {
+      document.removeEventListener("click", handleDocumentClick);
+    };
+  }, []);
+
+  const handleDocumentClick = (event) => {
+    if (
+      datePickerRef.current &&
+      !datePickerRef.current.contains(event.target)
+    ) {
+      datePickerRef.current.blur();
+    }
+  };
+
   return (
-    <div ignore-click >
-      {/* <label
-        style={{
-          color: "black",
-          fontWeight: 100,
-          fontSize: "medium",
-        }}
-      >
-        {props.label}
-      </label> */}
+    <div ref={datePickerRef}>
       <DatePicker
         {...props}
+        onClick={(event) => {
+          event.stopPropagation();
+        }}
         className={props.className}
         label={props.label}
         value={field.value && moment(new Date(), "MM/DD/YYYY")}
@@ -35,6 +48,8 @@ const MyDateField = ({...props }) => {
         onChange={(e) => {
           setValue(moment(e).format("MMM Do YY"));
         }}
+        getPopupContainer={() => datePickerRef.current}
+        // getPopupContainer={(trigger) => trigger.parentNode} // disable the default behavior of closing on a click outside
       />
       {touched && error ? (
         <div className={quickQuoteStyles.error}>

--- a/FormControls/MyDateField/index.js
+++ b/FormControls/MyDateField/index.js
@@ -14,30 +14,10 @@ const MyDateField = ({...props }) => {
 
   const datePickerRef = React.useRef(null);
 
-  React.useEffect(() => {
-    document.addEventListener("click", handleDocumentClick);
-
-    return () => {
-      document.removeEventListener("click", handleDocumentClick);
-    };
-  }, []);
-
-  const handleDocumentClick = (event) => {
-    if (
-      datePickerRef.current &&
-      !datePickerRef.current.contains(event.target)
-    ) {
-      datePickerRef.current.blur();
-    }
-  };
-
   return (
     <div ref={datePickerRef}>
       <DatePicker
         {...props}
-        onClick={(event) => {
-          event.stopPropagation();
-        }}
         className={props.className}
         label={props.label}
         value={field.value && moment(new Date(), "MM/DD/YYYY")}

--- a/FormControls/MyMultipleSelectCheckmarks/index.js
+++ b/FormControls/MyMultipleSelectCheckmarks/index.js
@@ -9,10 +9,7 @@ const options = [
   { label: "ADA Portable Restroom", value: "ADA Portable Restroom" },
   { label: "Hand Wash Station", value: "Hand Wash Station" },
 ];
-function handleMyMultipleSelectCheckmarksClick(event) {
-  event.stopPropagation();
-  // Handle the delivery date click event here
-}
+
 const MyMultipleSelectCheckmarks = ({ label, ...props }) => {
   const [field, meta, helpers] = useField(props);
   const { touched, error } = meta;
@@ -44,7 +41,7 @@ const MyMultipleSelectCheckmarks = ({ label, ...props }) => {
     maxTagCount: "responsive",
   };
   return (
-    <div ignore-click onClick={handleMyMultipleSelectCheckmarksClick}>
+    <div>
       <Space
         direction="vertical"
         style={{
@@ -53,7 +50,6 @@ const MyMultipleSelectCheckmarks = ({ label, ...props }) => {
       >
         <Select
           {...selectProps}
-          onClick={handleMyMultipleSelectCheckmarksClick}
           getPopupContainer={(trigger) => trigger.parentNode} // disable the default behavior of closing on a click outside
         />
       </Space>

--- a/FormControls/MyMultipleSelectCheckmarks/index.js
+++ b/FormControls/MyMultipleSelectCheckmarks/index.js
@@ -9,7 +9,10 @@ const options = [
   { label: "ADA Portable Restroom", value: "ADA Portable Restroom" },
   { label: "Hand Wash Station", value: "Hand Wash Station" },
 ];
-
+function handleMyMultipleSelectCheckmarksClick(event) {
+  event.stopPropagation();
+  // Handle the delivery date click event here
+}
 const MyMultipleSelectCheckmarks = ({ label, ...props }) => {
   const [field, meta, helpers] = useField(props);
   const { touched, error } = meta;
@@ -41,14 +44,18 @@ const MyMultipleSelectCheckmarks = ({ label, ...props }) => {
     maxTagCount: "responsive",
   };
   return (
-    <div ignore-click>
+    <div ignore-click onClick={handleMyMultipleSelectCheckmarksClick}>
       <Space
         direction="vertical"
         style={{
           width: "100%",
         }}
       >
-        <Select {...selectProps} />
+        <Select
+          {...selectProps}
+          onClick={handleMyMultipleSelectCheckmarksClick}
+          getPopupContainer={(trigger) => trigger.parentNode} // disable the default behavior of closing on a click outside
+        />
       </Space>
       {touched && error ? (
         <div className={quickQuoteStyles.error}>

--- a/components/QuickQuote.js
+++ b/components/QuickQuote.js
@@ -40,25 +40,23 @@ const QuickQuote = () => {
 
   const quickQuoteRef = React.useRef(null);
 
-  const pageClickEvent = (event) => {
-    if (quickQuoteRef.current && event.target.children[0]) {
-      if (
-        !quickQuoteRef.current.contains(event.target) &&
-        !event.target.children[0].hasAttribute("ignore-click")
-      ) {
+  const handleClickOutside = (event) => {
+    if (quickQuoteRef.current) {
+      if (!quickQuoteRef.current.contains(event.target)) {
         setQuickQuoteViewStatus(false);
-      } 
+      }
     }
   };
 
+
   React.useEffect(() => {
     if (typeof window) {
-      document.addEventListener("mousedown", pageClickEvent);
+      document.addEventListener("mousedown", handleClickOutside);
     }
     return () => {
-      document.removeEventListener("mousedown", pageClickEvent);
+      document.removeEventListener("mousedown", handleClickOutside);
     };
-  }, [quickQuoteViewStatus, quickQuoteRef]);
+  }, [quickQuoteRef]);
 
   const notify = () =>
     toast.success("Quick quote request sent !", {
@@ -96,9 +94,8 @@ const QuickQuote = () => {
               const res = await axios.post(`/api/quickQuote`, values);
               res.status === 200 && notify();
               console.log(res);
-
             } catch (err) {
-              console.log(err)
+              console.log(err);
             }
             resetForm({
               portableUnits: [],
@@ -174,10 +171,10 @@ const QuickQuote = () => {
                 <Button
                   variant="contained"
                   sx={{
-                    background: '#162184',
-                    borderRadius:0,
-                    '&:hover': {
-                      background:"#101B80",
+                    background: "#162184",
+                    borderRadius: 0,
+                    "&:hover": {
+                      background: "#101B80",
                     },
                   }}
                   endIcon={<SendIcon />}

--- a/pages/api/quickQuote.js
+++ b/pages/api/quickQuote.js
@@ -1,6 +1,6 @@
 const nodemailer = require("nodemailer");
 
-export default async function quickQuoteHandler(req, res) {
+export default async function quoteHandler(req, res) {
   const {
     query: { id, name },
     method,
@@ -22,23 +22,8 @@ export default async function quickQuoteHandler(req, res) {
         "November",
         "December",
       ];
-      const deliveryDate = new Date(`${req.body.deliveryDate}`);
 
-      const longDeliveryDate = `${
-        months[deliveryDate.getMonth()]
-      } ${deliveryDate.getDate()}, ${deliveryDate.getFullYear()}`;
-
-      const pickupDate = new Date(`${req.body.pickupDate}`);
-
-      const longPickupDate = `${
-        months[pickupDate.getMonth()]
-      } ${pickupDate.getDate()}, ${pickupDate.getFullYear()}`;
-
-      const promptQuoteData = req.body;
-
-      const productsArray = promptQuoteData.products;
-      const products = productsArray.map((element) => element.label);
-      
+      const quickQuoteData = req.body;
       const transporter = nodemailer.createTransport({
         host: "smtp.zoho.in",
         port: 465,
@@ -56,15 +41,41 @@ export default async function quickQuoteHandler(req, res) {
         subject: "Reliable Portable: Quick Quote", // Subject line
         text: ``, // plain text body
         html: `
-          <div><h4>From:</h4> <p>${promptQuoteData.fullName}</p></div>
-            <div><h4>Email:</h4> <p>${promptQuoteData.email}</p></div>
-            <div><h4>Phone:</h4> <p>${promptQuoteData.phone}</p></div>
-            <div><h4>Zip Code:</h4> <p>${promptQuoteData.zip}</p></div>
-            <div><h4>Products:</h4> <p>${products}</p></div>
-            <div><h4>Delivery Date:</h4><p>${longDeliveryDate}</p></div>
-            <div><h4>Pickup Date:</h4><p>${longPickupDate}</p></div>
-            <div><h4>Instructions:</h4> <p>${promptQuoteData.instructions}</p></div>
-          `, // html body
+          <div>
+            <div>
+                <h4>From:</h4>
+                <p>${quickQuoteData.fullName}</p>
+            </div>
+            <div>
+                <h4>Email:</h4>
+                <p>${quickQuoteData.email}</p>
+            </div>
+            <div>
+                <h4>Phone:</h4>
+                <p>${quickQuoteData.phone}</p>
+            </div>
+            <div>
+                <h4>Zip Code:</h4>
+                <p>${quickQuoteData.zip}</p>
+            </div>
+            <div>
+                <h4>Products:</h4>
+                <p>${quickQuoteData.portableUnits}</p>
+            </div>
+            <div>
+                <h4>Delivery Date:</h4>
+                <p>${quickQuoteData.deliveryDate}</p>
+            </div>
+            <div>
+                <h4>Pickup Date:</h4>
+                <p>${quickQuoteData.pickupDate}</p>
+            </div>
+            <div>
+                <h4>Instructions:</h4>
+                <p>${quickQuoteData.instructions}</p>
+            </div>
+          </div>
+        `, // html body
       });
       await res.status(200).json({ status: "Success" });
     } catch (err) {


### PR DESCRIPTION
In Ant Design's DatePicker component, getPopupContainer is a function that is used to specify the container for the picker's popup, which is where the calendar is displayed. By default, the container for the popup is the document body, which means that the popup will be displayed at the top level of the document and may cover other elements on the page.

The getPopupContainer function allows you to specify a custom container for the popup. In the code getPopupContainer={(trigger) => trigger.parentNode}, we are using an arrow function that takes the trigger parameter, which is the DOM element that triggers the display of the popup (in this case, the input field). The function then returns the parentNode of the trigger, which is the parent element of the input field.

By setting the popup container to be the parent of the input field, we are preventing the default behavior of the popup closing when the user clicks outside the calendar. When the user clicks outside the calendar, the click event is propagated to the parent element, which is the container element we specified with getPopupContainer. Since the popup is a child of this container, the click event is not propagated to the document body, and the popup is not closed.

In summary, by setting getPopupContainer={(trigger) => trigger.parentNode}, we are specifying that the parent element of the input field should be used as the container for the calendar popup, and this prevents the default behavior of the popup closing when the user clicks outside the calendar.